### PR TITLE
task(Dependency Security Vulnerabilities) : Upgrade the Gradle dep com.jcraft:jsch from 0.1.51 to 0.1.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.3
+- Security Vulnerabilities: Upgrade the Gradle dep com.jcraft:jsch from 0.1.51 to 0.1.54
+
 # 4.0.2
 - Ensure futures timeout rather than wait indefinitely
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'signing'
 group = 'com.feedhenry.gitlabshell'
 archivesBaseName = 'gitlab-shell-client'
 sourceCompatibility = 1.6
-version = '4.0.2'
+version = '4.0.3'
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.jcraft:jsch:0.1.51'
+    compile 'com.jcraft:jsch:0.1.54'
     compile 'org.apache.commons:commons-lang3:3.3.2'
     testCompile 'junit:junit:[4,5)'
     testCompile 'org.mockito:mockito-all:1.9.5'


### PR DESCRIPTION
## JIRA:
https://issues.jboss.org/browse/FH-4378

## WHAT:
Soliving Dependency Security Vulnerabilities.

## WHY:
Solve the following severity. 
<img width="880" alt="screen shot 2018-05-12 at 00 02 48" src="https://user-images.githubusercontent.com/7708031/39950248-e11a79d8-5577-11e8-90bd-3b4984990af6.png">

## HOW:
Upgrade the Gradle dep com.jcraft:jsch from `0.1.51` to `0.1.54`

## Usage
In all functions of this project. 

## Steps
This upgrade doesn't have break changes then check if the CI/process, Travis, will be finished with success since the deps will be installed and the project built. Also, the change is covered by the tests implemented in this project. 

<img width="972" alt="screen shot 2018-05-12 at 01 20 54" src="https://user-images.githubusercontent.com/7708031/39951539-c56c8e6e-5582-11e8-9432-ad08c65fde8a.png">

