### PR TITLE
fix(Gradle deprecations and build configuration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 gitlab-shell-client.iml
 .idea/
 .gradle
+gradle/
+gradlew
+gradlew.bat
 build/
+*out/
 gradle.properties
+.DS_Store
 
 *.pydevproject
 .metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.4
+- Fix Gradle deprecations and build configuration
+
 # 4.0.2
 - Ensure futures timeout rather than wait indefinitely
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'signing'
 group = 'com.feedhenry.gitlabshell'
 archivesBaseName = 'gitlab-shell-client'
 sourceCompatibility = 1.6
-version = '4.0.2'
+version = '4.0.4'
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,11 @@ uploadArchives {
       beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
       repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
+        authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', password: hasProperty('ossrhPassword')?ossrhPassword:'')
       }
 
       snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
+        authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', password: hasProperty('ossrhPassword')?ossrhPassword:'')
       }
 
       pom.project {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "net.saliman:gradle-cobertura-plugin:2.2.4"
+        classpath "net.saliman:gradle-cobertura-plugin:2.5.4"
     }
 }
 apply plugin: 'cobertura'


### PR DESCRIPTION
## JIRA:
https://issues.jboss.org/browse/FH-4895
https://issues.jboss.org/browse/FH-4896

## WHAT:
Solving the following deprecation warning. 

```
Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0
	at build_czkg4w24vid9gt5m3s8od9bxb.run(/Users/cmacedo/fh-lib/gitlab-shell-client/build.gradle:19)
	(Run with --stacktrace to get the full stack trace of this deprecation warning.)
:help
```
Solving the following Gradle setup error. 

```
* What went wrong:
A problem occurred evaluating root project 'gitlab-shell-client'.
> Could not get unknown property 'ossrhUsername' for object of type org.gradle.api.publication.maven.internal.deployer.DefaultGroovyMavenDeployer.
```

## WHY:
* Build and run all unit tests locally 
* Allow project work with future versions of Gradle

## HOW:
* Upgrade the Gradle plugin "net.saliman:gradle-cobertura-plugin:" from `2.2.4` to `2.5.4`
* Add validation to solve the local config error
* Add roles to .gitigonore releated to the newer version of plugin and Intellij IDEA/Gradle

## Steps
This upgrade doesn't have break changes then check if the CI/process, Travis, will be finished with success since the deps/plugin will be installed and the project built. Also, the change is covered by the tests implemented in this project. 

<img width="972" alt="screen shot 2018-05-12 at 01 20 54" src="https://user-images.githubusercontent.com/7708031/39951539-c56c8e6e-5582-11e8-9432-ad08c65fde8a.png">

However, is possible to import this project locally with Gradle and buind run the unit test. 